### PR TITLE
Thêm quản lý nhà cung cấp, khôi phục tài khoản (admin), thêm reCaptcha cho đăng ký

### DIFF
--- a/src/main/java/com/example/web/controller/LoginController.java
+++ b/src/main/java/com/example/web/controller/LoginController.java
@@ -1,7 +1,9 @@
 package com.example.web.controller;
 
+import com.example.web.dao.model.Level;
 import com.example.web.dao.model.User;
 import com.example.web.service.AuthService;
+import com.example.web.service.LogService;
 import com.example.web.utils.SessionManager;
 import com.google.gson.Gson;
 import jakarta.servlet.*;
@@ -17,6 +19,7 @@ import jakarta.servlet.annotation.WebServlet;
 @WebServlet(name = "LoginController", value = "/login")
 public class LoginController extends HttpServlet {
     AuthService service = new AuthService();
+    private final LogService logService = new LogService();
     int CAPTCHA_EXPIRY_TIME = 2 * 60 * 1000;
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -100,6 +103,7 @@ public class LoginController extends HttpServlet {
                     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 } else {
                     user.setPassword(null);
+                    logService.addLog(String.valueOf(Level.INFO), request, "Đăng nhập", "Success");
                     session.setAttribute("user", user);
                     session.setAttribute("userId", user.getId());
                     session.setAttribute("loginAttempts", 0);

--- a/src/main/java/com/example/web/controller/LoginFaceController.java
+++ b/src/main/java/com/example/web/controller/LoginFaceController.java
@@ -1,7 +1,9 @@
 package com.example.web.controller;
 
+import com.example.web.dao.model.Level;
 import com.example.web.dao.model.User;
 import com.example.web.service.AuthService;
+import com.example.web.service.LogService;
 import com.example.web.utils.SessionManager;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -22,6 +24,7 @@ import java.sql.SQLException;
 public class LoginFaceController extends HttpServlet {
     private static final String FACEBOOK_GRAPH_URL = "https://graph.facebook.com/me?fields=id,name,email&access_token=";
     private final AuthService service = new AuthService();
+    private final LogService logService = new LogService();
 
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -90,7 +93,7 @@ public class LoginFaceController extends HttpServlet {
                 return;
             }
             session.setAttribute("user", user);
-
+            logService.addLog(String.valueOf(Level.INFO), request, "Đăng nhập facebook", "Success");
 
             HttpSession oldSession = SessionManager.userSessions.get(user.getId() + "");
             if (oldSession != null && oldSession != session) {

--- a/src/main/java/com/example/web/controller/LoginGoogleController.java
+++ b/src/main/java/com/example/web/controller/LoginGoogleController.java
@@ -1,7 +1,9 @@
 package com.example.web.controller;
 
+import com.example.web.dao.model.Level;
 import com.example.web.dao.model.User;
 import com.example.web.service.AuthService;
+import com.example.web.service.LogService;
 import com.example.web.utils.SessionManager;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
@@ -22,6 +24,7 @@ import java.util.Collections;
 public class LoginGoogleController extends HttpServlet {
     private static final String CLIENT_ID = "891978819303-g9qeo4mmukj96bfr51iaaeheeqk1t1eo.apps.googleusercontent.com";
     private AuthService service = new AuthService();
+    private final LogService logService = new LogService();
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json");
@@ -105,6 +108,7 @@ public class LoginGoogleController extends HttpServlet {
 
                 session.setAttribute("uid", String.valueOf(user.getId()));
                 SessionManager.userSessions.put(user.getId()+"", session);
+                logService.addLog(String.valueOf(Level.INFO), request, "Đăng nhập Google", "Success");
 
 
                 response.getWriter().write("{\"success\": true}");

--- a/src/main/java/com/example/web/controller/admin/InventoryController/AddStockIn.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/AddStockIn.java
@@ -85,8 +85,9 @@ public class AddStockIn extends HttpServlet {
             int creatorId = Integer.parseInt(createdId);
             Date date = Date.valueOf(createdDate);
             double totalPrice = products.stream().mapToDouble(StockInItem::getTotalPrice).sum();
+            int supId = Integer.parseInt(supplier);
 
-            StockIn stockIn = new StockIn(0, creatorId, supplier, note, totalPrice, date, "Chưa áp dụng");
+            StockIn stockIn = new StockIn(0, creatorId, supId, note, totalPrice, date, "Chưa áp dụng");
             stockIn.setListPro(products);
 
             int stockInId = stockIOService.saveStockInWithItems(stockIn);

--- a/src/main/java/com/example/web/controller/admin/InventoryController/GetList.java
+++ b/src/main/java/com/example/web/controller/admin/InventoryController/GetList.java
@@ -1,10 +1,7 @@
 package com.example.web.controller.admin.InventoryController;
 
 import com.example.web.dao.model.*;
-import com.example.web.service.OrderService;
-import com.example.web.service.PaintingService;
-import com.example.web.service.SizeService;
-import com.example.web.service.StockIOService;
+import com.example.web.service.*;
 import io.opencensus.common.ServerStatsFieldEnums;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -23,6 +20,7 @@ public class GetList extends HttpServlet {
     private final PaintingService paintingService = new PaintingService();
     private final SizeService sizeService = new SizeService();
     private final OrderService orderService = new OrderService();
+    private final SupplierService supplierService = new SupplierService();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -31,11 +29,14 @@ public class GetList extends HttpServlet {
             List<StockOut> stockOut = stockIOService.getAllOut();
             List<Painting> p = paintingService.getAll();
             List<PaintingSize> s = sizeService.getAllSize();
+            List<Supplier> sup = supplierService.getAllSup();
+            System.out.println(sup);
             List<Order> o = orderService.getOrderByDelStatus("Chờ");
             req.setAttribute("stockIn", stockIn);
             req.setAttribute("stockOut", stockOut);
             p.sort(Comparator.comparingInt(Painting::getId));
             req.setAttribute("p", p);
+            req.setAttribute("sup", sup);
             req.setAttribute("s", s);
             req.setAttribute("o", o);
             req.getRequestDispatcher("stockIO.jsp").forward(req, resp);

--- a/src/main/java/com/example/web/controller/admin/SupplierController/Add.java
+++ b/src/main/java/com/example/web/controller/admin/SupplierController/Add.java
@@ -1,0 +1,75 @@
+package com.example.web.controller.admin.SupplierController;
+
+import com.example.web.dao.model.Supplier;
+import com.example.web.service.SupplierService;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("/admin/supplier/add")
+public class Add extends HttpServlet {
+    private final SupplierService supplierService = new SupplierService();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.setCharacterEncoding("UTF-8");
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        Gson gson = new Gson();
+        PrintWriter out = resp.getWriter();
+
+        String name = req.getParameter("name");
+        String email = req.getParameter("email");
+        String phone = req.getParameter("phone");
+        String address = req.getParameter("address");
+
+        try {
+            if (supplierService.findByEmail(email) != null) {
+                Map<String, Object> response = new HashMap<>();
+                response.put("status", "error");
+                response.put("message", "Email đã tồn tại, vui lòng chọn email khác.");
+                out.print(new Gson().toJson(response));
+                out.flush();
+                return;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        Supplier s = new Supplier();
+        s.setName(name);
+        s.setEmail(email);
+        s.setPhone(phone);
+        s.setAddress(address);
+
+        Supplier inserted = null;
+        try {
+            inserted = supplierService.addSupplier(s);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        if (inserted != null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "success");
+            response.put("supplier", inserted);
+            out.print(gson.toJson(response));
+        } else {
+            Map<String, Object> response = new HashMap<>();
+            response.put("status", "error");
+            response.put("message", "Không thể thêm nhà cung cấp.");
+            out.print(gson.toJson(response));
+        }
+        out.flush();
+    }
+}

--- a/src/main/java/com/example/web/controller/admin/SupplierController/Delete.java
+++ b/src/main/java/com/example/web/controller/admin/SupplierController/Delete.java
@@ -1,0 +1,37 @@
+package com.example.web.controller.admin.SupplierController;
+
+
+import com.example.web.service.SupplierService;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet("/admin/supplier/delete")
+public class Delete extends HttpServlet {
+    private final SupplierService supplierService = new SupplierService();
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+
+        try {
+            int id = Integer.parseInt(request.getParameter("id"));
+
+            boolean deleted = supplierService.deleteSupplier(id);
+
+            if (deleted) {
+                out.write("{\"status\": \"success\"}");
+            } else {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                out.write("{\"status\": \"fail\", \"message\": \"Không thể xoá nhà cung cấp.\"}");
+            }
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            out.write("{\"status\": \"error\", \"message\": \"" + e.getMessage() + "\"}");
+        }
+    }
+}

--- a/src/main/java/com/example/web/controller/admin/SupplierController/GetDetail.java
+++ b/src/main/java/com/example/web/controller/admin/SupplierController/GetDetail.java
@@ -1,0 +1,63 @@
+package com.example.web.controller.admin.SupplierController;
+
+import com.example.web.dao.model.Supplier;
+import com.example.web.service.SupplierService;
+import com.google.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("/admin/supplier/detail")
+public class GetDetail extends HttpServlet {
+    private final SupplierService supplierService = new SupplierService();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        PrintWriter out = resp.getWriter();
+        Gson gson = new Gson();
+
+        String idParam = req.getParameter("id");
+        Map<String, Object> response = new HashMap<>();
+
+        try {
+            if (idParam == null) {
+                response.put("status", "error");
+                response.put("message", "Thiếu ID nhà cung cấp.");
+                out.print(gson.toJson(response));
+                return;
+            }
+
+            int id = Integer.parseInt(idParam);
+            Supplier supplier = supplierService.getSupplierById(id);
+
+            if (supplier != null) {
+                response.put("status", "success");
+                response.put("supplier", supplier);
+            } else {
+                response.put("status", "error");
+                response.put("message", "Không tìm thấy nhà cung cấp.");
+            }
+        } catch (NumberFormatException e) {
+            response.put("status", "error");
+            response.put("message", "ID không hợp lệ.");
+        } catch (SQLException e) {
+            e.printStackTrace();
+            response.put("status", "error");
+            response.put("message", "Lỗi cơ sở dữ liệu.");
+        }
+
+        out.print(gson.toJson(response));
+        out.flush();
+    }
+}
+

--- a/src/main/java/com/example/web/controller/admin/SupplierController/Update.java
+++ b/src/main/java/com/example/web/controller/admin/SupplierController/Update.java
@@ -1,0 +1,71 @@
+package com.example.web.controller.admin.SupplierController;
+
+import com.example.web.dao.model.Supplier;
+import com.example.web.service.SupplierService;
+import com.google.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.Map;
+
+@WebServlet("/admin/supplier/update")
+public class Update extends HttpServlet {
+    private final SupplierService supplierService = new SupplierService();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.setCharacterEncoding("UTF-8");
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        Gson gson = new Gson();
+        PrintWriter out = resp.getWriter();
+
+        int id = Integer.parseInt(req.getParameter("id"));
+        String name = req.getParameter("name");
+        String email = req.getParameter("email");
+        String phone = req.getParameter("phone");
+        String address = req.getParameter("address");
+
+        try {
+            Supplier existing = supplierService.getSupplierById(id);
+            if (existing == null) {
+                out.print(gson.toJson(Map.of("status", "error", "message", "Nhà cung cấp không tồn tại.")));
+                out.flush();
+                return;
+            }
+
+            if (!existing.getEmail().equals(email)) {
+                Supplier byEmail = supplierService.findByEmail(email);
+                if (byEmail != null && byEmail.getId() != id) {
+                    out.print(gson.toJson(Map.of("status", "error", "message", "Email đã tồn tại.")));
+                    out.flush();
+                    return;
+                }
+            }
+
+            existing.setName(name);
+            existing.setEmail(email);
+            existing.setPhone(phone);
+            existing.setAddress(address);
+
+            boolean success = supplierService.updateSupplier(existing);
+            if (success) {
+                out.print(gson.toJson(Map.of("status", "success", "supplier", existing)));
+            } else {
+                out.print(gson.toJson(Map.of("status", "error", "message", "Cập nhật thất bại.")));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+            out.print(gson.toJson(Map.of("status", "error", "message", "Lỗi hệ thống.")));
+        }
+
+        out.flush();
+    }
+}
+

--- a/src/main/java/com/example/web/controller/admin/UserController/Delete.java
+++ b/src/main/java/com/example/web/controller/admin/UserController/Delete.java
@@ -88,7 +88,4 @@ public class Delete extends HttpServlet {
         out.print(gson.toJson(jsonResponse));
         out.flush();
     }
-
-
-
 }

--- a/src/main/java/com/example/web/controller/admin/UserController/GetListUser.java
+++ b/src/main/java/com/example/web/controller/admin/UserController/GetListUser.java
@@ -41,9 +41,11 @@ public class GetListUser extends HttpServlet {
         try {
 
             List<User> users = userService.getListUser();
+            List<User> userIsDelete = userService.getListUserIsDelete();
             List<Role> roles = roleService.getAllRoles();
             List<Permission> permissions = permissionService.getAll();
             req.setAttribute("users", users);
+            req.setAttribute("uDelete", userIsDelete);
             req.setAttribute("roles", roles);
             req.setAttribute("permissions", permissions);
          //   System.out.println("roles:"+ roles);

--- a/src/main/java/com/example/web/controller/admin/UserController/ResetPassword.java
+++ b/src/main/java/com/example/web/controller/admin/UserController/ResetPassword.java
@@ -1,12 +1,15 @@
 package com.example.web.controller.admin.UserController;
 
+import com.example.web.dao.model.User;
 import com.example.web.service.UserService;
+import com.example.web.utils.SessionManager;
 import com.google.gson.Gson;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -49,6 +52,13 @@ public class ResetPassword extends HttpServlet {
             boolean changed = userService.changePassword(Integer.parseInt(userId), newPass);
 
             if (changed) {
+                User up = userService.getUser(Integer.parseInt(userId));
+
+                HttpSession userSession = SessionManager.userSessions.get(up.getId()+"");
+                if (userSession != null) {
+                    userSession.invalidate();
+                    SessionManager.userSessions.remove(up.getEmail());
+                }
                 resp.setStatus(HttpServletResponse.SC_OK);
                 responseData.put("status", "success");
                 responseData.put("message", "Đổi mật khẩu thành công.");

--- a/src/main/java/com/example/web/controller/admin/UserController/Restore.java
+++ b/src/main/java/com/example/web/controller/admin/UserController/Restore.java
@@ -1,0 +1,66 @@
+package com.example.web.controller.admin.UserController;
+
+import com.example.web.controller.util.CheckPermission;
+import com.example.web.dao.model.User;
+import com.example.web.service.UserService;
+import com.google.gson.Gson;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("/admin/users/restore")
+public class Restore extends HttpServlet {
+    private UserService userService = new UserService();
+    private Gson gson = new Gson();
+    private final String permission= "DELETE_USERS";
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        Map<String, Object> jsonResponse = new HashMap<>();
+
+        HttpSession session = req.getSession();
+        User user = (User) session.getAttribute("user");
+
+        boolean hasPermission = CheckPermission.checkPermission(user, permission, "ADMIN");
+        if (!hasPermission) {
+            jsonResponse.put("status", "error");
+            jsonResponse.put("message", "bạn không có quyền");
+            return;
+        }
+
+        try {
+            int id = Integer.parseInt(req.getParameter("id"));
+            User u = userService.getUser(id);
+
+            User existingUser = userService.findByEmail(u.getEmail());
+            if (existingUser != null) {
+                jsonResponse.put("status", "error");
+                jsonResponse.put("message", "Email đã tồn tại. Không thể khôi phục.");
+                resp.getWriter().print(gson.toJson(jsonResponse));
+                return;
+            } else {
+                boolean restored = userService.restoreUser(id);
+                if (restored) {
+                    jsonResponse.put("status", "success");
+                    jsonResponse.put("message", "Khôi phục thành công!");
+                } else {
+                    jsonResponse.put("status", "error");
+                    jsonResponse.put("message", "Không thể khôi phục.");
+                }
+            }
+        } catch (Exception e) {
+            jsonResponse.put("status", "error");
+            jsonResponse.put("message", "Lỗi: " + e.getMessage());
+        }
+
+        resp.getWriter().print(gson.toJson(jsonResponse));
+    }
+}

--- a/src/main/java/com/example/web/controller/admin/UserController/Update.java
+++ b/src/main/java/com/example/web/controller/admin/UserController/Update.java
@@ -82,15 +82,19 @@ public class Update extends HttpServlet {
                     return;
                 }
 
-
-
                 if (fullName == null || fullName.isEmpty()) {
                     errors.put("changeNameError", "Họ và tên không được để trống!");
                 }
-                if (username == null || username.isEmpty()) {
-                    errors.put("changUsernameError", "Tên đăng nhập không được để trống!");
-                } else if (userService.findByUsername(username) != null && !username.equals(getCurrentUsername(id))) {
-                    errors.put("changUsernameError", "Tên đăng nhập đã tồn tại!");
+                User u = userService.getUser(id);
+                if (u.getGg_id() == null && u.getFb_id() == null) {
+                    if (username == null || username.isEmpty()) {
+                        errors.put("changUsernameError", "Tên đăng nhập không được để trống!");
+                    }
+                }
+                if (username != null && !username.isEmpty()) {
+                    if (userService.findByUsername(username) != null && !username.equals(getCurrentUsername(id))) {
+                        errors.put("changUsernameError", "Tên đăng nhập đã tồn tại!");
+                    }
                 }
 
                 if (email == null || email.isEmpty()) {

--- a/src/main/java/com/example/web/controller/util/OrderCacheManager.java
+++ b/src/main/java/com/example/web/controller/util/OrderCacheManager.java
@@ -5,8 +5,8 @@ import com.example.web.dao.model.Painting;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 
 public class OrderCacheManager {
@@ -18,22 +18,22 @@ public class OrderCacheManager {
 
     public OrderCacheManager() {
         currentOrdersCache = Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .expireAfterWrite(Duration.ofMinutes(10))
                 .maximumSize(1000)
                 .build();
 
         historyOrdersCache = Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .expireAfterWrite(Duration.ofMinutes(10))
                 .maximumSize(1000)
                 .build();
 
         adminCurrentOrdersCache = Caffeine.newBuilder()
-                .expireAfterWrite(5, TimeUnit.MINUTES)
+                .expireAfterWrite(Duration.ofMinutes(5))
                 .maximumSize(1)
                 .build();
 
         adminHistoryOrdersCache = Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .expireAfterWrite(Duration.ofMinutes(10))
                 .maximumSize(1)
                 .build();
     }

--- a/src/main/java/com/example/web/controller/util/PaintingCacheManager.java
+++ b/src/main/java/com/example/web/controller/util/PaintingCacheManager.java
@@ -2,13 +2,14 @@ package com.example.web.controller.util;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+
+import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import com.example.web.dao.model.Painting;
 
 public class PaintingCacheManager {
     private static final Cache<String, List<Painting>> paintingListCache = Caffeine.newBuilder()
-            .expireAfterWrite(10, TimeUnit.MINUTES)
+            .expireAfterWrite(Duration.ofMinutes(10))
             .maximumSize(100)
             .build();
 

--- a/src/main/java/com/example/web/controller/util/UserCacheManager.java
+++ b/src/main/java/com/example/web/controller/util/UserCacheManager.java
@@ -14,12 +14,12 @@ public class UserCacheManager {
 
     public UserCacheManager() {
         userByIdCache = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(10))
+                .expireAfterWrite(Duration.ofSeconds(10))
                 .maximumSize(1000)
                 .build();
 
         allUsersCache = Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(5))
+                .expireAfterWrite(Duration.ofSeconds(10))
                 .maximumSize(1)
                 .build();
     }

--- a/src/main/java/com/example/web/dao/StockIODao.java
+++ b/src/main/java/com/example/web/dao/StockIODao.java
@@ -1,10 +1,7 @@
 package com.example.web.dao;
 
 import com.example.web.dao.db.DbConnect;
-import com.example.web.dao.model.StockIn;
-import com.example.web.dao.model.StockInItem;
-import com.example.web.dao.model.StockOut;
-import com.example.web.dao.model.StockOutItem;
+import com.example.web.dao.model.*;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -12,7 +9,7 @@ import java.util.Date;
 import java.util.List;
 
 public class StockIODao {
-    static Connection conn = DbConnect.getConnection();
+    Connection conn = DbConnect.getConnection();
 
     public int saveStockInWithItems(StockIn stockIn) {
         try {
@@ -49,10 +46,10 @@ public class StockIODao {
         }
     }
     public int addStockInTrans(StockIn stockIn) throws SQLException{
-        String stockInSql = "INSERT INTO stock_in (createdId, supplier, note, totalPrice, importDate, status) VALUES (?, ?, ?, ?, ?, ?)";
+        String stockInSql = "INSERT INTO stock_in (createdId, supplierId, note, totalPrice, importDate, status) VALUES (?, ?, ?, ?, ?, ?)";
         try (PreparedStatement ps = conn.prepareStatement(stockInSql, Statement.RETURN_GENERATED_KEYS)) {
             ps.setInt(1, stockIn.getCreatedId());
-            ps.setString(2, stockIn.getSupplier());
+            ps.setInt(2, stockIn.getSupplierId());
             ps.setString(3, stockIn.getNote());
             ps.setDouble(4, stockIn.getTotalPrice());
             ps.setDate(5, new java.sql.Date(stockIn.getTransactionDate().getTime()));
@@ -73,7 +70,8 @@ public class StockIODao {
 
     public List<StockIn> getAll() throws SQLException{
         List<StockIn> stockInList = new ArrayList<>();
-        String sql = "SELECT si.*, u.fullName as createdName FROM stock_in si JOIN users u ON si.createdId = u.id";
+        String sql = "SELECT si.*, u.fullName as createdName, sup.name AS supplier FROM stock_in si JOIN users u ON si.createdId = u.id" +
+                " JOIN suppliers sup ON sup.id = si.supplierId";
 
         PreparedStatement ps = conn.prepareStatement(sql);
         ResultSet rs = ps.executeQuery();
@@ -122,7 +120,9 @@ public class StockIODao {
     public StockIn getStockInDetail(int id) throws SQLException {
         StockIn stockIn = null;
 
-        String sql = "SELECT si.*, u.fullName FROM stock_in si JOIN users u ON si.createdId = u.id WHERE si.id = ?";
+        String sql = "SELECT si.*, u.fullName, sup.name AS supplier FROM stock_in si JOIN users u ON si.createdId = u.id " +
+                "JOIN suppliers sup ON sup.id = si.supplierId " +
+                "WHERE si.id = ?";
         try (PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, id);
             ResultSet rs = ps.executeQuery();
@@ -219,7 +219,8 @@ public class StockIODao {
     }
     public StockIn getSIById(int stockInId) throws SQLException {
         StockIn stockIn = null;
-        String sql = "SELECT si.*, u.fullName as createdName FROM stock_in si JOIN users u ON si.createdId = u.id" +
+        String sql = "SELECT si.*, u.fullName as createdName, sup.name AS supplier FROM stock_in si JOIN users u ON si.createdId = u.id " +
+                "JOIN suppliers sup ON sup.id = si.supplierId" +
                 " WHERE si.id = ?";
 
         PreparedStatement ps = conn.prepareStatement(sql);

--- a/src/main/java/com/example/web/dao/SupplierDao.java
+++ b/src/main/java/com/example/web/dao/SupplierDao.java
@@ -1,0 +1,118 @@
+package com.example.web.dao;
+
+import com.example.web.dao.db.DbConnect;
+import com.example.web.dao.model.Supplier;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SupplierDao {
+    Connection conn = DbConnect.getConnection();
+
+    public List<Supplier> getAllSuppliers() {
+        List<Supplier> list = new ArrayList<>();
+        String sql = "SELECT * FROM suppliers";
+        try (PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+
+            while (rs.next()) {
+                Supplier s = new Supplier();
+                s.setId(rs.getInt("id"));
+                s.setName(rs.getString("name"));
+                s.setEmail(rs.getString("email"));
+                s.setPhone(rs.getString("phone"));
+                s.setAddress(rs.getString("address"));
+
+                list.add(s);
+            }
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return list;
+    }
+
+
+
+    public Supplier getSupplierById(int id) throws SQLException {
+        String sql = "SELECT * FROM suppliers WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Supplier supplier = new Supplier();
+                    supplier.setId(rs.getInt("id"));
+                    supplier.setName(rs.getString("name"));
+                    supplier.setEmail(rs.getString("email"));
+                    supplier.setPhone(rs.getString("phone"));
+                    supplier.setAddress(rs.getString("address"));
+                    return supplier;
+                }
+            }
+        }
+        return null;
+    }
+
+    public Supplier insertSupplier(Supplier s) throws SQLException {
+        String sql = "INSERT INTO suppliers(name, email, phone, address) VALUES (?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, s.getName());
+            ps.setString(2, s.getEmail());
+            ps.setString(3, s.getPhone());
+            ps.setString(4, s.getAddress());
+
+            int affectedRows = ps.executeUpdate();
+            if (affectedRows > 0) {
+                try (ResultSet rs = ps.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        int generatedId = rs.getInt(1);
+                        s.setId(generatedId);
+                        return s;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+
+    public boolean updateSupplier(Supplier s) throws SQLException {
+        String sql = "UPDATE suppliers SET name=?, email=?, phone=?, address=? WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, s.getName());
+            ps.setString(2, s.getEmail());
+            ps.setString(3, s.getPhone());
+            ps.setString(4, s.getAddress());
+            ps.setInt(5, s.getId());
+            return ps.executeUpdate() > 0;
+        }
+    }
+
+    public boolean deleteSupplier(int id) throws SQLException {
+        String sql = "DELETE FROM suppliers WHERE id=?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            return ps.executeUpdate() > 0;
+        }
+    }
+    public Supplier findByEmail(String email) throws SQLException {
+        String sql = "SELECT * FROM suppliers WHERE email = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, email);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    Supplier s = new Supplier(
+                            rs.getInt("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("phone"),
+                            rs.getString("address")
+                    );
+                    return s;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/web/dao/UserDao.java
+++ b/src/main/java/com/example/web/dao/UserDao.java
@@ -36,6 +36,7 @@ public class UserDao {
             u.setRole(roles);
             u.setAddress(rs.getString("address"));
             u.setPhone(rs.getString("phone"));
+            u.setStatus(rs.getString("status"));
             users.add(u);
         }
         return users;
@@ -59,6 +60,8 @@ public class UserDao {
             u.setPhone(rs.getString("phone"));
             u.setPassword(rs.getString("password"));
             u.setStatus(rs.getString("status"));
+            u.setGg_id(rs.getString("gg_id"));
+            u.setFb_id(rs.getString("fb_id"));
             return u;
         }
         return null;
@@ -618,25 +621,30 @@ public class UserDao {
     }
     public List<User> getListUserIsDelete() throws SQLException {
         List<User> users = new ArrayList<>();
-        String sql = "select * from users WHERE status IN ('Đã xóa')";
-        PreparedStatement ps = conn.prepareStatement(sql);
-        ResultSet rs = ps.executeQuery();
+        String sql = "SELECT * FROM users WHERE status = 'Đã xóa'";
 
-        while (rs.next()) {
-            User u = new User();
-            u.setId(rs.getInt("id"));
-            u.setUsername(rs.getString("username"));
-            u.setFullName(rs.getString("fullName"));
-            u.setEmail(rs.getString("email"));
-            Set<Role> roles = roleDao.getRolesByUserId(u.getId());
-            u.setRole(roles);
-            u.setAddress(rs.getString("address"));
-            u.setPhone(rs.getString("phone"));
-            users.add(u);
+        try (PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+
+            while (rs.next()) {
+                User u = new User();
+                u.setId(rs.getInt("id"));
+                u.setUsername(rs.getString("username"));
+                u.setFullName(rs.getString("fullName"));
+                u.setEmail(rs.getString("email"));
+                u.setAddress(rs.getString("address"));
+                u.setPhone(rs.getString("phone"));
+                u.setStatus(rs.getString("status"));
+
+                Set<Role> roles = roleDao.getRolesByUserId(u.getId());
+                u.setRole(roles);
+
+                users.add(u);
+            }
         }
         return users;
-
     }
+
     public void updateStatusDeletedForExpiredTokens() {
         String updateSql = "UPDATE users u " +
                 "JOIN tokens t ON u.id = t.userId " +
@@ -656,6 +664,20 @@ public class UserDao {
 
         } catch (SQLException e) {
             e.printStackTrace();
+        }
+    }
+    public boolean updateStatusUser(int id, String status){
+        String sql = "UPDATE users SET status = ? WHERE id = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, status);
+            ps.setInt(2, id);
+
+            int rowsAffected = ps.executeUpdate();
+            return rowsAffected > 0;
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+            return false;
         }
     }
 

--- a/src/main/java/com/example/web/dao/model/StockIn.java
+++ b/src/main/java/com/example/web/dao/model/StockIn.java
@@ -8,6 +8,7 @@ public class StockIn {
     private int id;
     private int createdId;
     private String createdName;
+    private int supplierId;
     private String supplier;
     private String note;
     private Date transactionDate;
@@ -15,10 +16,10 @@ public class StockIn {
     private List<StockInItem> listPro = new ArrayList<>();
     private String status;
 
-    public StockIn(int id, int createdId, String supplier, String note, double totalPrice, Date transactionDate, String status) {
+    public StockIn(int id, int createdId, int supplierId, String note, double totalPrice, Date transactionDate, String status) {
         this.id = id;
         this.createdId = createdId;
-        this.supplier = supplier;
+        this.supplierId = supplierId;
         this.note = note;
         this.totalPrice = totalPrice;
         this.transactionDate = transactionDate;
@@ -107,5 +108,13 @@ public class StockIn {
 
     public void setStatus(String status) {
         this.status = status;
+    }
+
+    public int getSupplierId() {
+        return supplierId;
+    }
+
+    public void setSupplierId(int supplierId) {
+        this.supplierId = supplierId;
     }
 }

--- a/src/main/java/com/example/web/dao/model/Supplier.java
+++ b/src/main/java/com/example/web/dao/model/Supplier.java
@@ -1,0 +1,66 @@
+package com.example.web.dao.model;
+
+public class Supplier {
+    private int id;
+    private String name;
+    private String email;
+    private String phone;
+    private String address;
+
+    public Supplier(int id, String name, String email, String phone, String address) {
+    }
+
+    public Supplier() {
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "Supplier{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", email='" + email + '\'' +
+                ", phone='" + phone + '\'' +
+                ", address='" + address + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/example/web/service/SupplierService.java
+++ b/src/main/java/com/example/web/service/SupplierService.java
@@ -1,0 +1,34 @@
+package com.example.web.service;
+
+import com.example.web.dao.SupplierDao;
+import com.example.web.dao.model.Supplier;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class SupplierService {
+    private SupplierDao supdao = new SupplierDao();
+
+    public List<Supplier> getAllSup() throws SQLException {
+        return supdao.getAllSuppliers();
+    }
+    public Supplier addSupplier(Supplier sup) throws SQLException {
+        return supdao.insertSupplier(sup);
+    }
+
+    public Supplier findByEmail(String email) throws SQLException {
+        return supdao.findByEmail(email);
+    }
+
+    public Supplier getSupplierById(int id) throws SQLException {
+        return supdao.getSupplierById(id);
+    }
+
+    public boolean updateSupplier(Supplier existing) throws SQLException {
+        return supdao.updateSupplier(existing);
+    }
+
+    public boolean deleteSupplier(int id) throws SQLException {
+        return supdao.deleteSupplier(id);
+    }
+}

--- a/src/main/java/com/example/web/service/UserService.java
+++ b/src/main/java/com/example/web/service/UserService.java
@@ -53,8 +53,6 @@ public class UserService {
         return userDao.getUser(i);
     }
 
-
-
     public User findByUsername(String username) throws SQLException {
         return userDao.findByUsername(username);
     }
@@ -111,4 +109,11 @@ public class UserService {
         System.out.println(user.getAllRolePermission());
     }
 
+    public List<User> getListUserIsDelete() throws SQLException {
+        return userDao.getListUserIsDelete();
+    }
+
+    public boolean restoreUser(int id) {
+        return userDao.updateStatusUser(id, "Hoạt động");
+    }
 }

--- a/src/main/webapp/admin/stockIO.jsp
+++ b/src/main/webapp/admin/stockIO.jsp
@@ -5,369 +5,498 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Admin Panel</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css" rel="stylesheet">
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
-  <!-- DataTables Buttons CSS -->
-  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Panel</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/1.11.5/css/jquery.dataTables.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.datatables.net/1.11.5/js/jquery.dataTables.min.js"></script>
+    <!-- DataTables Buttons CSS -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css">
 
-  <!-- DataTables Buttons JavaScript -->
-  <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
-  <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
-  <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+    <!-- DataTables Buttons JavaScript -->
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+    <script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
-  <style>
-    .sidebar {
-    height: 100vh;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 250px;
-    background-color: #343a40;
-    color: white;
-    padding: 20px 10px;
-  }
-  .sidebar a {
-    color: white;
-    text-decoration: none;
-    display: block;
-    padding: 10px;
-    margin-bottom: 5px;
-  }
-  .sidebar a:hover {
-    background-color: #495057;
-    border-radius: 5px;
-  }
-  .content {
-    margin-left: 260px;
-    padding: 20px;
-  }
-  </style>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <style>
+        .sidebar {
+            height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 250px;
+            background-color: #343a40;
+            color: white;
+            padding: 20px 10px;
+        }
+
+        .sidebar a {
+            color: white;
+            text-decoration: none;
+            display: block;
+            padding: 10px;
+            margin-bottom: 5px;
+        }
+
+        .sidebar a:hover {
+            background-color: #495057;
+            border-radius: 5px;
+        }
+
+        .content {
+            margin-left: 260px;
+            padding: 20px;
+        }
+    </style>
 
 </head>
 <body>
 <%@ include file="/admin/sidebar.jsp" %>
 
 <div class="content">
-  <div class="card mb-4">
-    <div class="card-header bg-success text-white" style="background: #e7621b !important;">
-      <h4>Quản lý xuất/nhập kho</h4>
+    <div class="card mb-4">
+        <div class="card-header bg-success text-white" style="background: #e7621b !important;">
+            <h4>Quản lý xuất/nhập kho</h4>
+        </div>
+        <div class="card-body">
+            <button class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#addStockModal">
+                + Thêm Phiếu Nhập kho
+            </button>
+            <button class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#addStockOutModal">
+                + Thêm Phiếu Xuất kho
+            </button>
+
+            <div class="table-section">
+                <div class="card-header bg-success text-white mt-4" style="background: #198754 !important;">
+                    <h5>Nhập Kho</h5>
+                </div>
+                <table id="importTable" class="table table-bordered display">
+                    <thead>
+                    <tr>
+                        <th>Mã Phiếu</th>
+                        <th>Ngày Tạo</th>
+                        <th>Người tạo</th>
+                        <th>Nhà cung cấp</th>
+                        <th>Tổng Tiền</th>
+                        <th>Ghi Chú</th>
+                        <th>Hành Động</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="si" items="${stockIn}">
+                        <tr data-si-id="${si.id}">
+                            <td>${si.id}</td>
+                            <td>${si.transactionDate}</td>
+                            <td>${si.createdName}</td>
+                            <td>${si.supplier}</td>
+                            <f:formatNumber var="formatted" value="${si.totalPrice}" pattern="#,##0"/>
+                            <td>${fn:replace(formatted, ',', '.')} ₫</td>
+                            <td>${si.note}</td>
+                            <td>
+                                <button class="btn btn-sm btn-info viewDetailSIButton" data-stockin-id="${si.id}"
+                                        data-bs-toggle="modal" data-bs-target="#detailModal">Chi tiết
+                                </button>
+                                <c:if test="${si.status == 'Chưa áp dụng'}">
+                                    <button class="btn btn-sm btn-danger deleteStockInButton" data-id="${si.id}">Xoá
+                                    </button>
+                                </c:if>
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="table-section">
+                <div class="card-header bg-success text-white mt-4" style="background: #198754 !important;">
+                    <h5>Xuất Kho</h5>
+                </div>
+                <table id="exportTable" class="table table-bordered display">
+                    <thead>
+                    <tr>
+                        <th>Mã Phiếu</th>
+                        <th>Ngày Tạo</th>
+                        <th>Người tạo</th>
+                        <th>Lý do</th>
+                        <th>Tổng Tiền</th>
+                        <th>Ghi Chú</th>
+                        <th>Hành Động</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="so" items="${stockOut}">
+                        <tr data-so-id="${so.id}">
+                            <td>${so.id}</td>
+                            <td>${so.transactionDate}</td>
+                            <td>${so.createdName}</td>
+                            <td>${so.reason}</td>
+                            <f:formatNumber var="formatted" value="${so.totalPrice}" pattern="#,##0"/>
+                            <td>${fn:replace(formatted, ',', '.')} ₫</td>
+                            <td>${so.note}</td>
+                            <td>
+                                <button class="btn btn-sm btn-info viewDetailSOButton" data-stockout-id="${so.id}"
+                                        data-bs-toggle="modal" data-bs-target="#detailModalSo">Chi tiết
+                                </button>
+                                <c:if test="${so.status == 'Chưa áp dụng'}">
+                                    <button class="btn btn-sm btn-danger deleteStockOButton" data-id="${so.id}">Xoá
+                                    </button>
+                                </c:if>
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
+            <div class="table-section">
+                <div class="card-header bg-success text-white mt-4" style="background: #198754 !important;">
+                    <h5>Nhà cung cấp</h5>
+                </div>
+                <button class="btn btn-success mb-3 mt-5" data-bs-toggle="modal" data-bs-target="#addSupplierModal">
+                    + Thêm Nhà Cung Cấp
+                </button>
+                <table id="supTable" class="table table-bordered display">
+                    <thead>
+                    <tr>
+                        <th>Mã số</th>
+                        <th>Tên</th>
+                        <th>Email</th>
+                        <th>Số điện thoại</th>
+                        <th>Địa chỉ</th>
+                        <th>Hành Động</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <c:forEach var="s" items="${sup}">
+                        <tr data-sup-id="${s.id}">
+                            <td>${s.id}</td>
+                            <td>${s.name}</td>
+                            <td>${s.phone}</td>
+                            <td>${s.email}</td>
+                            <td>${s.address}</td>
+                            <td>
+                                <button class="btn btn-sm btn-warning editSupplierModal" data-sup-id="${s.id}"
+                                        data-bs-toggle="modal" data-bs-target="#editSupplierModal">Sửa
+                                </button>
+                                <button class="btn btn-sm btn-danger deleteSupButton" data-id="${s.id}">Xoá
+                                </button>
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
-    <div class="card-body">
-      <button class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#addStockModal">
-        + Thêm Phiếu Nhập kho
-      </button>
-      <button class="btn btn-success mb-3" data-bs-toggle="modal" data-bs-target="#addStockOutModal">
-        + Thêm Phiếu Xuất kho
-      </button>
-
-      <div class="table-section">
-        <div class="card-header bg-success text-white mt-4" style="background: #198754 !important;">
-          <h5>Nhập Kho</h5>
+    <!-- Modal Thêm Nhà Cung Cấp -->
+    <div class="modal fade" id="addSupplierModal" tabindex="-1" aria-labelledby="addSupplierModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <form id="addSupplierForm">
+                <div class="modal-content">
+                    <div class="modal-header bg-success text-white">
+                        <h5 class="modal-title" id="addSupplierModalLabel">Thêm Nhà Cung Cấp</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">Tên nhà cung cấp</label>
+                            <input type="text" name="name" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Số điện thoại</label>
+                            <input type="text" name="phone" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Địa chỉ</label>
+                            <input type="text" name="address" class="form-control">
+                        </div>
+                        <input type="hidden" name="status" value="active">
+                    </div>
+                    <div class="modal-footer">
+                        <button type="submit" class="btn btn-success">Lưu</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                    </div>
+                </div>
+            </form>
         </div>
-        <table id="importTable" class="table table-bordered display">
-          <thead>
-          <tr>
-            <th>Mã Phiếu</th>
-            <th>Ngày Tạo</th>
-            <th>Người tạo</th>
-            <th>Nhà cung cấp</th>
-            <th>Tổng Tiền</th>
-            <th>Ghi Chú</th>
-            <th>Hành Động</th>
-          </tr>
-          </thead>
-          <tbody>
-          <c:forEach var="si" items="${stockIn}">
-            <tr data-si-id="${si.id}">
-              <td>${si.id}</td>
-              <td>${si.transactionDate}</td>
-              <td>${si.createdName}</td>
-              <td>${si.supplier}</td>
-              <f:formatNumber var="formatted" value="${si.totalPrice}" pattern="#,##0" />
-              <td>${fn:replace(formatted, ',', '.')} ₫</td>
-              <td>${si.note}</td>
-              <td>
-                <button class="btn btn-sm btn-info viewDetailSIButton" data-stockin-id="${si.id}" data-bs-toggle="modal" data-bs-target="#detailModal">Chi tiết</button>
-                <c:if test="${si.status == 'Chưa áp dụng'}">
-                  <button class="btn btn-sm btn-danger deleteStockInButton" data-id="${si.id}">Xoá</button>
-                </c:if>
-              </td>
-            </tr>
-          </c:forEach>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="table-section">
-        <div class="card-header bg-success text-white mt-4" style="background: #198754 !important;">
-          <h5>Xuất Kho</h5>
-        </div>
-        <table id="exportTable" class="table table-bordered display">
-          <thead>
-          <tr>
-            <th>Mã Phiếu</th>
-            <th>Ngày Tạo</th>
-            <th>Người tạo</th>
-            <th>Lý do</th>
-            <th>Tổng Tiền</th>
-            <th>Ghi Chú</th>
-            <th>Hành Động</th>
-          </tr>
-          </thead>
-          <tbody>
-              <c:forEach var="so" items="${stockOut}">
-                <tr data-so-id="${so.id}">
-                  <td>${so.id}</td>
-                  <td>${so.transactionDate}</td>
-                  <td>${so.createdName}</td>
-                  <td>${so.reason}</td>
-                  <f:formatNumber var="formatted" value="${so.totalPrice}" pattern="#,##0" />
-                  <td>${fn:replace(formatted, ',', '.')} ₫</td>
-                  <td>${so.note}</td>
-                  <td>
-                    <button class="btn btn-sm btn-info viewDetailSOButton" data-stockout-id="${so.id}" data-bs-toggle="modal" data-bs-target="#detailModalSo">Chi tiết</button>
-                    <c:if test="${so.status == 'Chưa áp dụng'}">
-                      <button class="btn btn-sm btn-danger deleteStockOButton" data-id="${so.id}">Xoá</button>
-                    </c:if>
-                  </td>
-                </tr>
-              </c:forEach>
-          </tbody>
-        </table>
-      </div>
     </div>
-  </div>
-
-  <div class="modal fade" id="detailModal" tabindex="-1" aria-labelledby="detailModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <div class="modal-header bg-primary text-white">
-          <h5 class="modal-title" id="detailModalLabel">Chi tiết Phiếu Nhập kho</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+    <!-- Modal Sửa Nhà Cung Cấp -->
+    <div class="modal fade" id="editSupplierModal" tabindex="-1" aria-labelledby="editSupplierModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <form id="editSupplierForm">
+                <div class="modal-content">
+                    <div class="modal-header bg-warning text-white">
+                        <h5 class="modal-title" id="editSupplierModalLabel">Sửa Nhà Cung Cấp</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                    </div>
+                    <div class="modal-body">
+                        <input type="hidden" name="id" id="editSupplierId">
+                        <div class="mb-3">
+                            <label class="form-label">Tên nhà cung cấp</label>
+                            <input type="text" name="name" id="editSupplierName" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Email</label>
+                            <input type="email" name="email" id="editSupplierEmail" class="form-control" required>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Số điện thoại</label>
+                            <input type="text" name="phone" id="editSupplierPhone" class="form-control">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">Địa chỉ</label>
+                            <input type="text" name="address" id="editSupplierAddress" class="form-control">
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="submit" class="btn btn-warning">Cập nhật</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                    </div>
+                </div>
+            </form>
         </div>
-        <div class="modal-body">
-          <p><strong>Mã phiếu:</strong> <span id="siId"></span></p>
-          <p><strong>Người lập:</strong> <span id="createBy"></span></p>
-          <p><strong>Loại:</strong> Nhập kho</p>
-          <p><strong>Nhà cung cấp:</strong> <span id="detailSup"></span></p>
-          <p><strong>Ngày tạo:</strong> <span id="importDate"></span></p>
-          <p><strong>Ghi chú:</strong> <span id="note"></span></p>
-
-          <table id="stockInItem" class="table table-bordered mt-3">
-            <thead>
-            <tr>
-              <th>Mã SP</th>
-              <th>Tên SP</th>
-              <th>Kích thước</th>
-              <th>Số lượng</th>
-              <th>Đơn giá</th>
-              <th>Thành tiền</th>
-              <th>Ghi chú</th>
-            </tr>
-            </thead>
-            <tbody id="stockinItemBody">
-            </tbody>
-          </table>
-        </div>
-        <div class="modal-footer">
-          <strong class="me-auto"> Tổng tiền: <span id="totalPrice"></span></strong>
-          <button type="button" class="btn btn-success" id="applyBtn">Áp dụng</button>
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
-        </div>
-      </div>
     </div>
-  </div>
 
+    <div class="modal fade" id="detailModal" tabindex="-1" aria-labelledby="detailModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title" id="detailModalLabel">Chi tiết Phiếu Nhập kho</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Mã phiếu:</strong> <span id="siId"></span></p>
+                    <p><strong>Người lập:</strong> <span id="createBy"></span></p>
+                    <p><strong>Loại:</strong> Nhập kho</p>
+                    <p><strong>Nhà cung cấp:</strong> <span id="detailSup"></span></p>
+                    <p><strong>Ngày tạo:</strong> <span id="importDate"></span></p>
+                    <p><strong>Ghi chú:</strong> <span id="note"></span></p>
 
-<div class="modal fade" id="detailModalSo" tabindex="-1" aria-labelledby="detailModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header bg-primary text-white">
-        <h5 class="modal-title" id="detailModalLabelSO">Chi tiết Phiếu Xuất kho</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
-      </div>
-      <div class="modal-body">
-        <p><strong>Mã phiếu:</strong> <span id="soId"></span></p>
-        <p><strong>Người lập:</strong> <span id="createBySo"></span></p>
-        <p><strong>Loại:</strong> Xuất kho</p>
-        <p><strong>Lý do:</strong> <span id="reasonSO"></span></p>
-        <p><strong>Mã đơn hàng (giao hàng):</strong> <span id="orderIdSO"></span></p>
-        <p><strong>Ngày tạo:</strong> <span id="exportDate"></span></p>
-        <p><strong>Ghi chú:</strong> <span id="noteSo"></span></p>
-
-        <table id="stockOutItem" class="table table-bordered mt-3">
-          <thead>
-          <tr>
-            <th>Mã SP</th>
-            <th>Tên SP</th>
-            <th>Kích thước</th>
-            <th>Số lượng</th>
-            <th>Đơn giá</th>
-            <th>Thành tiền</th>
-            <th>Ghi chú</th>
-          </tr>
-          </thead>
-          <tbody id="stockOutItemBody">
-          </tbody>
-        </table>
-      </div>
-      <div class="modal-footer">
-        <f:formatNumber var="formatted" value="${sessionScope.cart.totalPrice}" pattern="#,##0" />
-        <strong class="me-auto"> Tổng tiền: <span id="totalPriceSo">${fn:replace(formatted, ',', '.')} ₫</span></strong>
-        <button type="button" class="btn btn-success" id="applySOBtn">Áp dụng</button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
-      </div>
+                    <table id="stockInItem" class="table table-bordered mt-3">
+                        <thead>
+                        <tr>
+                            <th>Mã SP</th>
+                            <th>Tên SP</th>
+                            <th>Kích thước</th>
+                            <th>Số lượng</th>
+                            <th>Đơn giá</th>
+                            <th>Thành tiền</th>
+                            <th>Ghi chú</th>
+                        </tr>
+                        </thead>
+                        <tbody id="stockinItemBody">
+                        </tbody>
+                    </table>
+                </div>
+                <div class="modal-footer">
+                    <strong class="me-auto"> Tổng tiền: <span id="totalPrice"></span></strong>
+                    <button type="button" class="btn btn-success" id="applyBtn">Áp dụng</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                </div>
+            </div>
+        </div>
     </div>
-  </div>
-</div>
+
+
+    <div class="modal fade" id="detailModalSo" tabindex="-1" aria-labelledby="detailModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title" id="detailModalLabelSO">Chi tiết Phiếu Xuất kho</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+                </div>
+                <div class="modal-body">
+                    <p><strong>Mã phiếu:</strong> <span id="soId"></span></p>
+                    <p><strong>Người lập:</strong> <span id="createBySo"></span></p>
+                    <p><strong>Loại:</strong> Xuất kho</p>
+                    <p><strong>Lý do:</strong> <span id="reasonSO"></span></p>
+                    <p><strong>Mã đơn hàng (giao hàng):</strong> <span id="orderIdSO"></span></p>
+                    <p><strong>Ngày tạo:</strong> <span id="exportDate"></span></p>
+                    <p><strong>Ghi chú:</strong> <span id="noteSo"></span></p>
+
+                    <table id="stockOutItem" class="table table-bordered mt-3">
+                        <thead>
+                        <tr>
+                            <th>Mã SP</th>
+                            <th>Tên SP</th>
+                            <th>Kích thước</th>
+                            <th>Số lượng</th>
+                            <th>Đơn giá</th>
+                            <th>Thành tiền</th>
+                            <th>Ghi chú</th>
+                        </tr>
+                        </thead>
+                        <tbody id="stockOutItemBody">
+                        </tbody>
+                    </table>
+                </div>
+                <div class="modal-footer">
+                    <f:formatNumber var="formatted" value="${sessionScope.cart.totalPrice}" pattern="#,##0"/>
+                    <strong class="me-auto"> Tổng tiền: <span
+                            id="totalPriceSo">${fn:replace(formatted, ',', '.')} ₫</span></strong>
+                    <button type="button" class="btn btn-success" id="applySOBtn">Áp dụng</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <div class="modal fade" id="addStockModal" tabindex="-1" aria-labelledby="addStockModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header bg-success text-white">
-        <h5 class="modal-title" id="addStockModalLabel">Tạo Phiếu Nhập Kho</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label>Người thực hiện:</label>
-          <input type="text" id="user" class="form-control" value="${sessionScope.user.fullName}" readonly>
-          <input type="hidden" id="userId" name="userId" value="${sessionScope.user.id}">
-        </div>
-        <div class="mb-3">
-          <label>Nhà cung cấp:</label>
-          <input type="text" id="supplier" class="form-control" >
-        </div>
-        <div class="mb-3">
-          <label>Ngày nhập:</label>
-          <input type="date" id="createdDate" class="form-control" >
-        </div>
-        <div class="mb-3">
-          <label>Ghi chú:</label>
-          <textarea class="form-control" id="noteInput"></textarea>
-        </div>
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title" id="addStockModalLabel">Tạo Phiếu Nhập Kho</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label>Người thực hiện:</label>
+                    <input type="text" id="user" class="form-control" value="${sessionScope.user.fullName}" readonly>
+                    <input type="hidden" id="userId" name="userId" value="${sessionScope.user.id}">
+                </div>
+                <div class="mb-3">
+                    <label>Nhà cung cấp:</label>
+                    <select id="supplier" class="form-control" name="supplierId">
+                        <option>--Chọn nhà cung cấp--</option>
+                        <c:forEach var="s" items="${sup}">
+                            <option value="${s.id}">${s.name}</option>
+                        </c:forEach>
+                    </select>
+                </div>
+                <div class="mb-3">
+                    <label>Ngày nhập:</label>
+                    <input type="date" id="createdDate" class="form-control">
+                </div>
+                <div class="mb-3">
+                    <label>Ghi chú:</label>
+                    <textarea class="form-control" id="noteInput"></textarea>
+                </div>
 
-        <div class="mb-2 d-flex justify-content-between align-items-center">
-          <h5>Danh sách sản phẩm</h5>
-          <button class="btn btn-sm btn-primary btn-addProd" onclick="addEmptyRow('productTable')">+ Thêm sản phẩm</button>
+                <div class="mb-2 d-flex justify-content-between align-items-center">
+                    <h5>Danh sách sản phẩm</h5>
+                    <button class="btn btn-sm btn-primary btn-addProd" onclick="addEmptyRow('productTable')">+ Thêm sản
+                        phẩm
+                    </button>
+                </div>
+                <div style="max-height: 300px; overflow-y: auto;">
+                    <table class="table table-bordered" id="productTable">
+                        <thead>
+                        <tr>
+                            <th>Mã Sản phẩm</th>
+                            <th>Size</th>
+                            <th>Số lượng</th>
+                            <th>Đơn giá</th>
+                            <th>Ghi chú</th>
+                            <th>Hành động</th>
+                        </tr>
+                        </thead>
+                        <tbody id="productBody">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-success" onclick="submitStockIn()">Lưu Phiếu Nhập</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+            </div>
         </div>
-        <div style="max-height: 300px; overflow-y: auto;">
-          <table class="table table-bordered" id="productTable">
-            <thead>
-          <tr>
-            <th>Mã Sản phẩm</th>
-            <th>Size</th>
-            <th>Số lượng</th>
-            <th>Đơn giá</th>
-            <th>Ghi chú</th>
-            <th>Hành động</th>
-          </tr>
-          </thead>
-          <tbody id="productBody">
-            </tbody>
-        </table>
-        </div>
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-success" onclick="submitStockIn()">Lưu Phiếu Nhập</button>
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
-      </div>
     </div>
-  </div>
 </div>
 
 <div class="modal fade" id="addStockOutModal" tabindex="-1" aria-labelledby="addStockOutModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl">
-    <div class="modal-content">
-      <div class="modal-header bg-success text-white">
-        <h5 class="modal-title" id="addStockOutModalLabel">Tạo Phiếu Xuất Kho</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label>Người thực hiện:</label>
-          <input type="text" id="userSO" class="form-control" value="${sessionScope.user.fullName}" readonly>
-          <input type="hidden" id="userIdSO" name="userId" value="${sessionScope.user.id}">
-        </div>
-        <div class="mb-3">
-          <label>Lý do xuất kho:</label>
-          <select id="reason" class="form-select" onchange="onReasonChange(this)">
-              <option value="">-- Chọn lý do --</option>
-              <option value="Giao hàng">Giao hàng</option>
-              <option value="Xuất hỏng">Xuất hỏng</option>
-              <option value="Khác">Khác</option>
-          </select>
-        </div>
-        <div class="mb-3" id="otherReasonWrapper" style="display: none;">
-            <label>Nhập lý do khác:</label>
-            <input type="text" id="otherReason" class="form-control">
-        </div>
-        <div class="mb-3" id="orderSelectWrapper" style="display: none;">
-          <label>Chọn hóa đơn:</label>
-          <select id="orderSelect" class="form-select" onchange="onOrderChange(this)">
-            <option value="">-- Không chọn --</option>
-            <c:forEach var="o" items="${o}">
-              <option value="${o.id}">#${o.id} - ${o.paymentMethod} - ${o.recipientName}</option>
-            </c:forEach>
-          </select>
-        </div>
+    <div class="modal-dialog modal-xl">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title" id="addStockOutModalLabel">Tạo Phiếu Xuất Kho</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Đóng"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <label>Người thực hiện:</label>
+                    <input type="text" id="userSO" class="form-control" value="${sessionScope.user.fullName}" readonly>
+                    <input type="hidden" id="userIdSO" name="userId" value="${sessionScope.user.id}">
+                </div>
+                <div class="mb-3">
+                    <label>Lý do xuất kho:</label>
+                    <select id="reason" class="form-select" onchange="onReasonChange(this)">
+                        <option value="">-- Chọn lý do --</option>
+                        <option value="Giao hàng">Giao hàng</option>
+                        <option value="Xuất hỏng">Xuất hỏng</option>
+                        <option value="Khác">Khác</option>
+                    </select>
+                </div>
+                <div class="mb-3" id="otherReasonWrapper" style="display: none;">
+                    <label>Nhập lý do khác:</label>
+                    <input type="text" id="otherReason" class="form-control">
+                </div>
+                <div class="mb-3" id="orderSelectWrapper" style="display: none;">
+                    <label>Chọn hóa đơn:</label>
+                    <select id="orderSelect" class="form-select" onchange="onOrderChange(this)">
+                        <option value="">-- Không chọn --</option>
+                        <c:forEach var="o" items="${o}">
+                            <option value="${o.id}">#${o.id} - ${o.paymentMethod} - ${o.recipientName}</option>
+                        </c:forEach>
+                    </select>
+                </div>
 
-        <div class="mb-3">
-          <label>Ngày xuất kho:</label>
-          <input type="date" id="createdDateSO" class="form-control" >
-        </div>
-        <div class="mb-3">
-          <label>Ghi chú:</label>
-          <textarea class="form-control" id="noteOut"></textarea>
-        </div>
+                <div class="mb-3">
+                    <label>Ngày xuất kho:</label>
+                    <input type="date" id="createdDateSO" class="form-control">
+                </div>
+                <div class="mb-3">
+                    <label>Ghi chú:</label>
+                    <textarea class="form-control" id="noteOut"></textarea>
+                </div>
 
-        <div class="mb-2 d-flex justify-content-between align-items-center">
-            <h5>Danh sách sản phẩm</h5>
-            <button class="btn btn-sm btn-primary " id="addProdOut"  onclick="addEmptyRow('productTableSO')">+ Thêm sản phẩm</button>
+                <div class="mb-2 d-flex justify-content-between align-items-center">
+                    <h5>Danh sách sản phẩm</h5>
+                    <button class="btn btn-sm btn-primary " id="addProdOut" onclick="addEmptyRow('productTableSO')">+
+                        Thêm sản phẩm
+                    </button>
+                </div>
+                <div style="max-height: 300px; overflow-y: auto;">
+                    <table class="table table-bordered" id="productTableSO">
+                        <thead>
+                        <tr>
+                            <th>Mã Sản phẩm</th>
+                            <th>Size</th>
+                            <th>Số lượng</th>
+                            <th>Đơn giá</th>
+                            <th>Ghi chú</th>
+                            <th>Hành động</th>
+                        </tr>
+                        </thead>
+                        <tbody id="productBodySO">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-success" onclick="submitStockOut()">Lưu Phiếu Xuất</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
+            </div>
         </div>
-        <div style="max-height: 300px; overflow-y: auto;">
-            <table class="table table-bordered" id="productTableSO">
-              <thead>
-              <tr>
-                <th>Mã Sản phẩm</th>
-                <th>Size</th>
-                <th>Số lượng</th>
-                <th>Đơn giá</th>
-                <th>Ghi chú</th>
-                <th>Hành động</th>
-              </tr>
-            </thead>
-            <tbody id="productBodySO">
-              </tbody>
-            </table>
-          </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-success" onclick="submitStockOut()">Lưu Phiếu Xuất</button>
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Đóng</button>
-      </div>
     </div>
-  </div>
 </div>
 <script src="${pageContext.request.contextPath}/assets/js/admin/stockIO.js"></script>
 <script>
-  function addEmptyRow(tableId) {
-    const tbody = document.getElementById(tableId).querySelector("tbody");
+    function addEmptyRow(tableId) {
+        const tbody = document.getElementById(tableId).querySelector("tbody");
 
-    const row = document.createElement("tr");
+        const row = document.createElement("tr");
 
-    row.innerHTML = `
+        row.innerHTML = `
     <td><select class="form-select product-select">
             <option value="">Chọn sản phẩm</option>
                     <c:forEach var="p" items="${p}">
@@ -388,9 +517,9 @@
     </td>
   `;
 
-    tbody.appendChild(row);
+        tbody.appendChild(row);
 
-  }
+    }
 </script>
 </body>
 </html>

--- a/src/main/webapp/admin/users.jsp
+++ b/src/main/webapp/admin/users.jsp
@@ -82,7 +82,8 @@
                     <th>Tên đầy đủ</th>
                     <th>Email</th>
                     <th>Số điện thoại</th>
-                    <th>quyền</th>
+                    <th>Trạng thái</th>
+                    <th>Quyền</th>
                     <th>Hành Động</th>
                 </tr>
                 </thead>
@@ -94,6 +95,7 @@
                     <td>${u.fullName}</td>
                     <td>${u.email}</td>
                     <td>${u.phone}</td>
+                    <td>${u.status}</td>
                     <td>
                     <c:forEach var="role" items="${u.roles}">
                         ${role.name}
@@ -161,7 +163,7 @@
                             <input type="hidden" id="editUserId" name="id" value="">
                             <div class="col-md-6">
                                 <label for="changUsername" class="form-label">Tên đăng nhập <span style="color: red;">*</span></label>
-                                <input type="text" class="form-control" id="changUsername" name="username" required>
+                                <input type="text" class="form-control" id="changUsername" name="username">
                                 <div class="error" id="changUsernameError"></div>
                             </div>
                         </div>
@@ -320,6 +322,57 @@
             </div>
         </div>
     </div>
+    <div class="card mb-4">
+        <div class="card-header bg-success text-white" style="background: #e7621b !important;">
+            <h4>Các tài khoản đã xóa</h4>
+        </div>
+
+        <div class="card-body">
+            <table id="usersIdDelete" class="table table-bordered display">
+                <div style="padding-bottom: 10px">
+                    <c:if test="${not empty message}">
+                        <div class="alert alert-success">
+                                ${message}
+                        </div>
+                    </c:if>
+                </div>
+                <thead>
+                <tr>
+                    <th>Mã người dùng</th>
+                    <th>Tên đăng nhập</th>
+                    <th>Tên đầy đủ</th>
+                    <th>Email</th>
+                    <th>Số điện thoại</th>
+                    <th>Trạng thái</th>
+                    <th>quyền</th>
+                    <th>Hành Động</th>
+                </tr>
+                </thead>
+                <tbody>
+                <c:forEach var="u" items="${uDelete}">
+                <tr>
+                    <td>${u.id}</td>
+                    <td>${u.username}</td>
+                    <td>${u.fullName}</td>
+                    <td>${u.email}</td>
+                    <td>${u.phone}</td>
+                    <td>${u.status}</td>
+                    <td>
+                        <c:forEach var="role" items="${u.roles}">
+                            ${role.name}
+                        </c:forEach>
+                    </td>
+                    <td>
+                        <button class="btn btn-success btn-sm restore-user-btn"
+                                data-user-id="${u.id}">
+                            <i class="fas fa-undo"></i> Khôi phục
+                        </button>
+                    </td>
+                    </c:forEach>
+                </tbody>
+            </table>
+        </div>
+    </div>
 
 
 </div>
@@ -336,6 +389,8 @@
                 { extend: 'pdf', title: 'Danh sách người dùng' },
                 { extend: 'print', title: 'Danh sách người dùng' }
             ]
+        });
+        $('#usersIdDelete').DataTable({
         });
     });
 

--- a/src/main/webapp/assets/js/authModal.js
+++ b/src/main/webapp/assets/js/authModal.js
@@ -158,6 +158,13 @@ $(document).ready(function () {
         let confirmPassword = $('#ConfirmRegisterPassword').val().trim();
         let fullName = $('#registerName').val().trim();
         let username = $('#registerUsername').val().trim();
+        $('#reCaptchaSError').text('');
+        const captchaResponse = grecaptcha.getResponse();
+
+        if (captchaResponse.length === 0) {
+            $('#reCaptchaSError').text('Vui lòng xác nhận bạn không phải robot!');
+            isValid = false;
+        }
 
         // Kiểm tra email hợp lệ
         let emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
@@ -204,10 +211,12 @@ $(document).ready(function () {
                 username: username,
                 password: password,
                 email: email,
-                phone: phone
+                phone: phone,
+                'g-recaptcha-response': captchaResponse
             },
             datatype: 'json',
             success: function(response){
+                grecaptcha.reset();
                 if (response.success) {
                     $(".loading-spinner").hide();
                     $(".loading-message").hide();
@@ -216,6 +225,7 @@ $(document).ready(function () {
                 }
             },
             error: function(xhr){
+                grecaptcha.reset();
                 $(".loading-spinner").hide();
                 $(".loading-message").hide();
                 $("button[type='submit']").attr("disabled", false);

--- a/src/main/webapp/partials/authModal.jsp
+++ b/src/main/webapp/partials/authModal.jsp
@@ -124,6 +124,8 @@
                                     <div class="error" id="confirmPasswordError"></div>
                                 </div>
                             </div>
+                            <div class="g-recaptcha mb-2" data-sitekey="6LcLlxUrAAAAAPXCQ0NU3bAIXe17zjg0aiZhyck-"></div>
+                            <div id="reCaptchaSError" class="text-danger mb-2"></div>
 
                             <button type="submit" class="btn btn-success w-100 login-btn">Đăng Ký</button>
                             <div class="loading-spinner">


### PR DESCRIPTION
**Mô tả**
Giải quyết issue: #110 
- Thêm quản lí nhà cung cấp ở trang xuất/nhập kho hàng, dùng modal cho thêm, sửa: name, email, phone, adddress
- Điều chỉnh nhập kho từ nhập thủ công nhà cung cấp qua chọn nhà cung cấp.
- Hiển thị danh sách tài khoản đã xóa ở trang quản lí user
- Mỗi dòng có nút khôi phục
- Chỉ khôi phục nếu không trùng email với cái tài khoản chưa bị xóa.
- Thêm reCaptcha cho đăng ký tài khoản.

Ngày: 04/06/2025
Đóng issue: #110 